### PR TITLE
Fix issue when using the multi line codec

### DIFF
--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -26,5 +26,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'jls-lumberjack', ['>=0.0.20']
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'stud'
+  s.add_development_dependency 'logstash-codec-multiline'
+  
 end
 

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-lumberjack'
-  s.version         = '0.1.3'
+  s.version         = '0.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/lumberjack_spec.rb
+++ b/spec/inputs/lumberjack_spec.rb
@@ -1,1 +1,57 @@
-require "logstash/devutils/rspec/spec_helper"
+# encoding: utf-8
+require "spec_helper"
+require "stud/temporary"
+require 'logstash/inputs/lumberjack'
+require "logstash/codecs/plain"
+require "logstash/codecs/multiline"
+
+describe LogStash::Inputs::Lumberjack do
+
+  let(:ssl_cert) { Stud::Temporary.pathname("ssl_certificate") }
+  let(:ssl_key)  { Stud::Temporary.pathname("ssl_key") }
+
+  let(:queue)  { Queue.new }
+  let(:config)   { { "port" => 0, "ssl_certificate" => ssl_cert, "ssl_key" => ssl_key, "type" => "example" } }
+
+
+  before do
+    system("openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{ssl_key} -out #{ssl_cert} -subj /CN=localhost > /dev/null 2>&1")
+  end
+
+  context "#register" do
+
+    it "raise no exception" do
+      plugin = LogStash::Inputs::Lumberjack.new(config)
+      expect { plugin.register}.not_to raise_error
+    end
+  end
+
+  describe "#processing of events" do
+
+    context "#codecs" do
+
+      let(:config) do
+        { "port" => 6969, "ssl_certificate" => ssl_cert, "ssl_key" => ssl_key,
+          "type" => "example", "codec" => codec }
+      end
+
+      let(:codec) { LogStash::Codecs::Multiline.new("pattern" => '\n', "what" => "previous") }
+      subject!(:lumberjack) { LogStash::Inputs::Lumberjack.new(config) }
+      let(:connection) { double("connection") }
+      let(:lines) { {"line" => "one\ntwo\n  two.2\nthree\n"} }
+
+      before(:each) do
+        allow(connection).to receive(:run).and_yield(lines)
+        lumberjack.register
+      end
+
+      it "clone the codec per connection" do
+        expect_any_instance_of(Lumberjack::Server).to receive(:accept).and_return(connection)
+        expect(lumberjack.codec).to receive(:clone).once
+        expect(lumberjack).to receive(:invoke).and_throw(:msg)
+        lumberjack.run(queue)
+      end
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/codecs/plain"


### PR DESCRIPTION
Made the codec server and connection independant, so there is no issue when using for example the multiline codec.

Fixes #1 

Relates and depends to: https://github.com/elasticsearch/logstash-forwarder/pull/364

Probably not the best solution, but a good workaround for now.