### PR TITLE
catch unhandled exception in input thread

### DIFF
--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -89,8 +89,12 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
 
   def invoke(connection, codec, &block)
     @threadpool.post do
-      connection.run do |fields|
-        block.call(codec, fields.delete("line"), fields)
+      begin
+        connection.run do |fields|
+          block.call(codec, fields.delete("line"), fields)
+        end
+      rescue => e
+        @logger.error("Exception in lumberjack input thread", :exception => e)
       end
     end
   end


### PR DESCRIPTION
Otherwise any unhandled exception from input thread crashes logstash. To reproduce you may open connection by openssl s_client, type something and just close connection.