### PR TITLE
Apply a threadpool to fix the OOM issue of Logstash

### DIFF
--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'jls-lumberjack', ['>=0.0.20']
+  s.add_runtime_dependency "concurrent-ruby"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'stud'
   s.add_development_dependency 'logstash-codec-multiline'
-  
 end
 

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-lumberjack'
-  s.version         = '0.1.5'
+  s.version         = '0.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/lumberjack_spec.rb
+++ b/spec/inputs/lumberjack_spec.rb
@@ -4,54 +4,96 @@ require "stud/temporary"
 require 'logstash/inputs/lumberjack'
 require "logstash/codecs/plain"
 require "logstash/codecs/multiline"
+require "logstash/event"
+require "lumberjack/client"
+require_relative "../support/logstash_test"
 
 describe LogStash::Inputs::Lumberjack do
-
-  let(:ssl_cert) { Stud::Temporary.pathname("ssl_certificate") }
-  let(:ssl_key)  { Stud::Temporary.pathname("ssl_key") }
-
+  let(:connection) { double("connection") }
+  let(:certificate) { LogStashTest.certificate }
+  let(:port) { LogStashTest.random_port }
   let(:queue)  { Queue.new }
-  let(:config)   { { "port" => 0, "ssl_certificate" => ssl_cert, "ssl_key" => ssl_key, "type" => "example" } }
+  let(:config)   { { "port" => 0, "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key, "type" => "example", "tags" => "lumberjack" } }
 
-
-  before do
-    system("openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{ssl_key} -out #{ssl_cert} -subj /CN=localhost > /dev/null 2>&1")
-  end
+  subject(:lumberjack) { LogStash::Inputs::Lumberjack.new(config) }
 
   context "#register" do
-
     it "raise no exception" do
       plugin = LogStash::Inputs::Lumberjack.new(config)
-      expect { plugin.register}.not_to raise_error
+      expect { plugin.register }.not_to raise_error
     end
   end
 
   describe "#processing of events" do
+    let(:lines) { {"line" => "one\ntwo\n  two.2\nthree\n", "tags" => ["syslog"]} }
+
+    before do
+      allow(connection).to receive(:run).and_yield(lines)
+      lumberjack.register
+      expect_any_instance_of(Lumberjack::Server).to receive(:accept).and_return(connection)
+    end
 
     context "#codecs" do
-
       let(:config) do
-        { "port" => 6969, "ssl_certificate" => ssl_cert, "ssl_key" => ssl_key,
+        { "port" => port, "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key,
           "type" => "example", "codec" => codec }
       end
 
       let(:codec) { LogStash::Codecs::Multiline.new("pattern" => '\n', "what" => "previous") }
-      subject!(:lumberjack) { LogStash::Inputs::Lumberjack.new(config) }
-      let(:connection) { double("connection") }
-      let(:lines) { {"line" => "one\ntwo\n  two.2\nthree\n"} }
-
-      before(:each) do
-        allow(connection).to receive(:run).and_yield(lines)
-        lumberjack.register
-      end
-
       it "clone the codec per connection" do
-        expect_any_instance_of(Lumberjack::Server).to receive(:accept).and_return(connection)
         expect(lumberjack.codec).to receive(:clone).once
         expect(lumberjack).to receive(:invoke).and_throw(:msg)
         lumberjack.run(queue)
       end
-
     end
   end
+
+  context "when we have the maximum clients connected" do
+    let(:max_clients) { 1 }
+    let(:window_size) { 1 }
+    let(:config) do 
+      {
+        "port" => port,
+        "ssl_certificate" => certificate.ssl_cert,
+        "ssl_key" => certificate.ssl_key,
+        "type" => "testing",
+        "max_clients" => max_clients
+      }
+    end
+
+    let(:client_options) do
+      {
+        :port => port,
+        :address => "127.0.0.1",
+        :ssl_certificate => certificate.ssl_cert,
+        :window_size => window_size
+      }
+    end
+
+    before do
+      lumberjack.register
+
+      @server = Thread.new do
+        lumberjack.run(queue)
+      end
+
+      sleep(0.1) # wait for the server to correctly accept messages
+    end
+
+    after do
+      @server.raise(LogStash::ShutdownSignal)
+      @server.join
+    end
+
+    it "stops accepting new connection" do
+      client1 = Lumberjack::Socket.new(client_options)
+      client2 = Lumberjack::Socket.new(client_options)
+
+      expect { 
+        (window_size + 1).times do
+          client2.write_hash({"line" => "message"}) 
+        end
+      }.to raise_error(IOError)
+    end
+ end
 end

--- a/spec/support/logstash_test.rb
+++ b/spec/support/logstash_test.rb
@@ -1,0 +1,23 @@
+require "stud/temporary"
+module LogStashTest
+  class Certicate
+    attr_reader :ssl_key, :ssl_cert
+
+    def initialize
+      @ssl_cert = Stud::Temporary.pathname("ssl_certificate")
+      @ssl_key = Stud::Temporary.pathname("ssl_key")
+
+      system("openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{ssl_key} -out #{ssl_cert} -subj /CN=localhost > /dev/null 2>&1")
+    end
+  end
+
+  class << self
+    def certificate
+      Certicate.new
+    end
+
+    def random_port
+      rand(2000..10000)
+    end
+  end
+end


### PR DESCRIPTION
Add a simple threadpool to limit the number of connection to the current lumberjack server.

fixes: https://github.com/logstash-plugins/logstash-input-lumberjack/issues/10