### PR TITLE
Fix/circuit breaker

### DIFF
--- a/lib/logstash/circuit_breaker.rb
+++ b/lib/logstash/circuit_breaker.rb
@@ -1,0 +1,96 @@
+require "thread"
+require "cabin"
+
+module LogStash
+  # Largely inspired by Martin's fowler circuit breaker
+  class CircuitBreaker
+    class OpenBreaker < StandardError; end
+
+    # Error threshold before opening the breaker,
+    # if the breaker is open it wont execute the code.
+    DEFAULT_ERROR_THRESHOLD = 5
+
+    # Recover time after the breaker is open to start
+    # executing the method again.
+    DEFAULT_TIME_BEFORE_RETRY = 30
+
+    # Exceptions catched by the circuit breaker,
+    # too much errors and the breaker will trip.
+    DEFAULT_EXCEPTION_RESCUED = [StandardError]
+
+    def initialize(name, options = {}, &block)
+      @exceptions = Array(options.fetch(:exceptions, [StandardError]))
+      @error_threshold = options.fetch(:error_threshold, DEFAULT_ERROR_THRESHOLD)
+      @time_before_retry = options.fetch(:time_before_retry, DEFAULT_TIME_BEFORE_RETRY)
+      @block = block
+      @name = name
+      @mutex = Mutex.new
+      reset
+    end
+
+    def execute(args = nil)
+      case state
+      when :open
+        logger.warn("CircuitBreaker::Open", :name => @name)
+        raise OpenBreaker, "for #{@name}"
+      when :close, :half_open
+        if block_given?
+          yield args
+        else
+          @block.call(args)
+        end
+
+        if state == :half_open
+          logger.warn("CircuitBreaker::Close", :name => @name)
+          reset
+        end
+      end
+    rescue *@exceptions => e
+      logger.warn("CircuitBreaker::rescuing exceptions", :name => @name, :exception => e.class)
+      increment_errors(e)
+    end
+
+    def closed?
+      state == :close || state == :half_open
+    end
+
+    private
+    def logger
+      @logger ||= Cabin::Channel.get(LogStash)
+    end
+
+    def reset
+      @mutex.synchronize do
+        @errors_count = 0
+        @last_failure_time = nil
+      end
+    end
+
+    def increment_errors(exception)
+      @mutex.synchronize do
+        @errors_count += 1
+        @last_failure_time = Time.now
+
+        logger.debug("CircuitBreaker increment errors", 
+                     :errors_count => @errors_count, 
+                     :error_threshold => @error_threshold,
+                     :exception => exception.class,
+                     :message => exception.message) if logger.debug?
+      end
+    end
+
+    def state
+      @mutex.synchronize do
+        if @errors_count >= @error_threshold
+          if Time.now - @last_failure_time > @time_before_retry
+            :half_open
+          else
+            :open
+          end
+        else
+          :close
+        end
+      end
+    end
+  end
+end

--- a/lib/logstash/sized_queue_timeout.rb
+++ b/lib/logstash/sized_queue_timeout.rb
@@ -1,0 +1,58 @@
+require "concurrent/atomic/condition"
+require "thread"
+
+module LogStash
+  # Minimal subset implement of a SizedQueue supporting
+  # a timeout option on the lock.
+  #
+  # This will be part of the main Logstash's sized queue
+  class SizedQueueTimeout
+    class TimeoutError < StandardError; end
+
+    DEFAULT_TIMEOUT = 2 # in seconds
+
+    def initialize(max_size, options = {})
+      @condition_in = Concurrent::Condition.new
+      @condition_out = Concurrent::Condition.new
+
+      @max_size = max_size
+      @queue = []
+      @mutex = Mutex.new
+    end
+
+    def push(obj, timeout = DEFAULT_TIMEOUT)
+      @mutex.synchronize do
+        while full? # wake up check
+          result = @condition_out.wait(@mutex, timeout) 
+          raise TimeoutError if result.timed_out?
+        end
+
+        @queue << obj
+        @condition_in.signal
+
+        return obj
+      end
+    end
+    alias_method :<<, :push
+
+    def size
+      @mutex.synchronize { @queue.size }
+    end
+
+    def pop_no_timeout
+      @mutex.synchronize do
+        @condition_in.wait(@mutex) while @queue.empty? # Wake up check
+
+        obj = @queue.shift
+        @condition_out.signal
+
+        return obj
+      end
+    end
+
+    private
+    def full?
+      @queue.size == @max_size
+    end
+  end
+end

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'stud'
   s.add_development_dependency 'logstash-codec-multiline'
   s.add_development_dependency "flores"
+  s.add_development_dependency "stud"
 end
 

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'stud'
   s.add_development_dependency 'logstash-codec-multiline'
+  s.add_development_dependency "flores"
 end
 

--- a/spec/logstash/circuit_breaker_spec.rb
+++ b/spec/logstash/circuit_breaker_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+require "logstash/circuit_breaker"
+
+class DummyErrorTest < StandardError; end
+
+describe LogStash::CircuitBreaker do
+  let(:error_threshold) { 1 }
+  let(:options) do 
+    {
+      :exceptions => [DummyErrorTest],
+      :error_threshold => error_threshold 
+    }
+  end
+
+  subject { LogStash::CircuitBreaker.new("testing", options) }
+
+
+  it "closed by default" do
+    expect(subject.closed?).to eq(true)
+  end
+
+  context "when having too many errors" do
+    let(:future_time) { Time.now + 3600 }
+    before do
+      subject.execute do
+        raise DummyErrorTest
+      end
+    end
+
+    it "raised an exception if we have too many errors" do
+      expect {
+        subject.execute do
+          raise DummyErrorTest
+        end
+      }.to raise_error(LogStash::CircuitBreaker::OpenBreaker)
+    end
+
+    it "sets the breaker to open" do
+      expect(subject.closed?).to eq(false)
+    end
+
+    it "resets the breaker after the time before retry" do
+      expect(Time).to receive(:now).at_least(1).and_return(future_time)
+      expect(subject.closed?).to eq(true)
+    end
+
+    it "doesnt run the command" do
+      runned = false
+
+      begin
+        subject.execute do
+          runned = true
+        end
+      rescue LogStash::CircuitBreaker::OpenBreaker
+      end
+
+      expect(runned).to eq(false)
+    end
+  end
+end

--- a/spec/logstash/size_queue_timeout_spec.rb
+++ b/spec/logstash/size_queue_timeout_spec.rb
@@ -5,8 +5,6 @@ require "flores/random"
 describe "LogStash::SizedQueueTimeout" do
   let(:max_size) { Flores::Random.integer(2..100) }
   let(:element) { Flores::Random.text(0..100) }
-  # let(:max_size) { 3 }
-  # let(:element) { "Hello Logstash" }
 
   subject { LogStash::SizedQueueTimeout.new(max_size) }
   
@@ -63,6 +61,17 @@ describe "LogStash::SizedQueueTimeout" do
       end
 
       expect(blocked.status).to eq(false)
+    end
+  end
+
+  context "when the queue is not full" do
+    before :each { Flores::Random.iterations(0..max_size) { subject << "hurray" }  }
+
+    it "doesnt block on pop" do
+
+    end
+
+    it "doesnt block on push" do
     end
   end
 end

--- a/spec/logstash/size_queue_timeout_spec.rb
+++ b/spec/logstash/size_queue_timeout_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+require "logstash/sized_queue_timeout"
+require "flores/random"
+
+describe "LogStash::SizedQueueTimeout" do
+  let(:max_size) { Flores::Random.integer(2..100) }
+  let(:element) { Flores::Random.text(0..100) }
+  # let(:max_size) { 3 }
+  # let(:element) { "Hello Logstash" }
+
+  subject { LogStash::SizedQueueTimeout.new(max_size) }
+  
+  it "adds element to the queue" do
+    subject << element
+    expect(subject.size).to eq(1)
+  end
+
+  it "allow to pop element from the queue" do
+    subject << element
+    subject << "awesome"
+
+    expect(subject.pop_no_timeout).to eq(element)
+  end
+  
+  context "when the queue is full" do
+    before do
+      max_size.times do
+        subject << element
+      end
+    end
+
+    it "block with a timeout" do
+      expect {
+        subject << element
+      }.to raise_error(LogStash::SizedQueueTimeout::TimeoutError)
+    end
+
+    it "unblock when we pop" do
+      blocked = testing_thread do
+        subject << element
+      end
+
+      expect(blocked.status).to eq("sleep")
+
+      testing_thread do
+        subject.pop_no_timeout
+      end
+
+      expect(blocked.status).to eq(false)
+    end
+  end
+
+  context "when the queue is empty" do
+    it "block on pop" do
+      blocked = testing_thread do
+        subject.pop_no_timeout
+      end
+
+      expect(blocked.status).to eq("sleep")
+
+      testing_thread do
+        subject << element
+      end
+
+      expect(blocked.status).to eq(false)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/plain"
+require_relative "support/logstash_test"

--- a/spec/support/logstash_test.rb
+++ b/spec/support/logstash_test.rb
@@ -21,3 +21,13 @@ module LogStashTest
     end
   end
 end
+
+def testing_thread(&block)
+  th = Thread.new do
+    block.call
+  end
+  #
+  # wait for the thread to spin
+  sleep(0.1)
+  th
+end

--- a/spec/support/logstash_test.rb
+++ b/spec/support/logstash_test.rb
@@ -21,13 +21,3 @@ module LogStashTest
     end
   end
 end
-
-def testing_thread(&block)
-  th = Thread.new do
-    block.call
-  end
-  #
-  # wait for the thread to spin
-  sleep(0.1)
-  th
-end


### PR DESCRIPTION
This pull request aim to applies the pipeline back pressure up to logstash-forwarder (LSF)  clients.
In the current implementation the lumberjack input create a new thread per LSF connection and start accepting new data right away, if the **pipeline** is slow or there is a transient or a permanent error on the output, each connection threads will block and remain in this state until the pipeline unblock. On the LSF side theses block will be detected as a connection timeout and they will reconnect to logstash and restransmit the event frame, Logstash will accept this new connection, read the data and block again. LSF will never stop restransmitting data and logstash will create threads until the process
is out of memory.

This pull request bring a few features to the lumberjack input:

* A Small buffered queue with a blocking timeout, this value is a bit higher than the LSF threshold, a connection thread will never stay open forever.
* A Circuit breaker, if there is too many timeout errors the breaker will open and logstash will start refusing new connection for a period of time.
* Threads are now added to a cached threadpool backed by concurrent-ruby and java ThreadPoolExecutor (currently unbounded)

*The timeout option of the size queue will be migrated to the main logstash queue in a future pull request*

## RUN 
**Platform**:
MacBook Pro (Retina, 13-inch, Mid 2014) (no completly idle so it may impact results)
MacOS X 10.10.3
3 GHz Intel Core i7
16 GB 1600 MHz DDR3

**Config**
Logstash: https://gist.github.com/f0a2ef9566c4cd35c6bf
Logstash-Forwarder: https://gist.github.com/a55d409c68c18cd48c28

Logstash command: bin/logstash -f ~/es/logstash-config/lumberjack_test/input.conf | pv -Wbart > /dev/null

Sample.log  ~ 5.1 gigs file (Let the tests ran for ~4, enough to warm the jvm)
Extract of the log: https://gist.github.com/061c05fbade8c4eddd52

## Performance tests

| connection | Baseline v0.1.5 | SizeQueue + Timeout + Circuit Breaker |
| --------------- | -------------------- | ---------------------------------------------------- |
| 1  | 5.71MiB 0:04:00 [28.3KiB/s] [24.4KiB/s] | 6.61MiB 0:04:07 [27.6KiB/s] [27.4KiB/s] |
| 3  | 9.88MiB 0:04:02 [37.2KiB/s] [41.8KiB/s] | 9.13MiB 0:04:04 [38.8KiB/s] [38.3KiB/s] |

##### Resiliency tests

Config:

Logstash: https://gist.github.com/f0a2ef9566c4cd35c6bf
Logstash-Forwarder: https://gist.github.com/a55d409c68c18cd48c28

Scenario:
Permanent error

Setup: 1, LSF -> Logstash -> ES
Stop ES, LSF timeout, try to reconnect and get connection refused
Restart ES, LSF reconnect and resend events

Using the sleep filter we can simulate congestion in the pipeline, if there is too much congestion LSF will timeout and reconnect. The threads will be killed by timeout event and free the memory or they will 