### PR TITLE
Small typo in the warn message `max_clients_queue` intead of `max_clients`

### DIFF
--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -82,7 +82,7 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
     if @threadpool.length < @threadpool.max_length
       block.call(connection, @codec.clone)
     else
-      @logger.warn("Lumberjack input, maximum connection exceeded, new connection are rejected.", :max_clients => @max_clients_queue)
+      @logger.warn("Lumberjack input, maximum connection exceeded, new connection are rejected.", :max_clients => @max_clients)
       connection.close
     end
   end

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-lumberjack'
-  s.version         = '0.1.7'
+  s.version         = '0.1.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
wrong instance variable in the warn message ref: https://github.com/elastic/logstash/issues/3277

fixes: #26 