### PR TITLE
Don't overwrite fields

### DIFF
--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -109,7 +109,14 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
 
     @codec.decode(line, identity(fields)) do |event|
       decorate(event)
-      fields.each { |k,v| event[k] = v; v.force_encoding(Encoding::UTF_8) }
+      fields.each do |k, v|
+        # Don't overwrite a field if it already exists in the event.
+        next if event[k]
+
+        v.force_encoding(Encoding::UTF_8)
+        event[k] = v
+      end
+
       block.call(event)
     end
   end


### PR DESCRIPTION
This should fix a bug where a user uses `codec => json` and has
a field named "host" in this json. The bug is that logstash-forwarder
will send a "host" field along with every event, and the lumberjack
input would previously ignore any previous value for the "host" field.
This is also fixed for "file" and "offset" fields.

Fixes #24
