### PR TITLE
Add option for an SSL certificate chain

### DIFF
--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -29,6 +29,9 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
   # SSL key passphrase to use.
   config :ssl_key_passphrase, :validate => :password
 
+  # Optional SSL certificate chain to use
+  config :ssl_cert_chain, :validate => :string
+
   # Number of maximum clients that the lumberjack input will accept, this allow you
   # to control the back pressure up to the client and stop logstash to go OOM with 
   # connection. This settings is a temporary solution and will be deprecated really soon.
@@ -45,7 +48,7 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
     @logger.info("Starting lumberjack input listener", :address => "#{@host}:#{@port}")
     @lumberjack = Lumberjack::Server.new(:address => @host, :port => @port,
       :ssl_certificate => @ssl_certificate, :ssl_key => @ssl_key,
-      :ssl_key_passphrase => @ssl_key_passphrase)
+      :ssl_key_passphrase => @ssl_key_passphrase, :ssl_cert_chain => @ssl_cert_chain)
 
     # Limit the number of thread that can be created by the
     # lumberjack output, if the queue is full the input will 

--- a/spec/inputs/lumberjack_spec.rb
+++ b/spec/inputs/lumberjack_spec.rb
@@ -13,7 +13,7 @@ describe LogStash::Inputs::Lumberjack do
   let(:certificate) { LogStashTest.certificate }
   let(:port) { LogStashTest.random_port }
   let(:queue)  { Queue.new }
-  let(:config)   { { "port" => 0, "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key, "type" => "example", "tags" => "lumberjack" } }
+  let(:config)   { { "port" => 0, "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key, "ssl_cert_chain" => nil, "type" => "example", "tags" => "lumberjack" } }
 
   subject(:lumberjack) { LogStash::Inputs::Lumberjack.new(config) }
 
@@ -36,7 +36,7 @@ describe LogStash::Inputs::Lumberjack do
     context "#codecs" do
       let(:config) do
         { "port" => port, "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key,
-          "type" => "example", "codec" => codec }
+          "ssl_cert_chain" => nil, "type" => "example", "codec" => codec }
       end
 
       let(:codec) { LogStash::Codecs::Multiline.new("pattern" => '\n', "what" => "previous") }
@@ -56,6 +56,7 @@ describe LogStash::Inputs::Lumberjack do
         "port" => port,
         "ssl_certificate" => certificate.ssl_cert,
         "ssl_key" => certificate.ssl_key,
+        "ssl_cert_chain" => nil,
         "type" => "testing",
         "max_clients" => max_clients
       }


### PR DESCRIPTION
Pending acceptance of https://github.com/elastic/ruby-lumberjack/pull/2, this will allow users to specify a certificate chain instead of a certificate and single CA. In my testing, this worked with logstash-forwarder
