### PR TITLE
Make max_clients setting a no-op.

### DIFF
--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -29,12 +29,8 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
   # SSL key passphrase to use.
   config :ssl_key_passphrase, :validate => :password
 
-  # The lumberjack input using a fixed thread pool to do the actual work and
-  # will accept a number of client in a queue, before starting to refuse new
-  # connection. This solve an issue when logstash-forwarder clients are 
-  # trying to connect to logstash which have a blocked pipeline and will 
-  # make logstash crash with an out of memory exception.
-  config :max_clients, :validate => :number, :default => 1000
+  # This setting no longer has any effect and will be removed in a future release.
+  config :max_clients, :validate => :number, :deprecated => "This setting no longer has any effect. See https://github.com/logstash-plugins/logstash-input-lumberjack/pull/12 for the history of this change"
 
   # TODO(sissel): Add CA to authenticate clients with.
 
@@ -58,7 +54,6 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
     # start rejecting new connection and raise an exception
     @threadpool = Concurrent::ThreadPoolExecutor.new(
       :min_threads => 1,
-      :max_threads => @max_clients,
       :max_queue => 1, # in concurrent-ruby, bounded queue need to be at least 1.
       fallback_policy: :abort
     )

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -48,15 +48,6 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
       :ssl_certificate => @ssl_certificate, :ssl_key => @ssl_key,
       :ssl_key_passphrase => @ssl_key_passphrase)
 
-    # Limit the number of thread that can be created by the
-    # Limit the number of thread that can be created by the 
-    # lumberjack output, if the queue is full the input will 
-    # start rejecting new connection and raise an exception
-    @threadpool = Concurrent::ThreadPoolExecutor.new(
-      :min_threads => 1,
-      :max_queue => 1, # in concurrent-ruby, bounded queue need to be at least 1.
-      fallback_policy: :abort
-    )
     @threadpool = Concurrent::CachedThreadPool.new(:idletime => 15)
 
     # in 1.5 the main SizeQueue doesnt have the concept of timeout


### PR DESCRIPTION
The `max_clients` setting was only added as a shim until we were able to
make a better congestion control mechanism for lumberjack. #12
implemented the improvement with a circuit breaker, so we don't need
a connection cap anymore.