### PR TITLE
Use `require_relative` for the rspec helper to fix loading issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.0.2
+  - Use a `require_relative` for loading the spec helpers. (https://github.com/logstash-plugins/logstash-input-lumberjack/pull/35)
 # 1.0.1
   - Fix a randomization issue for rspec https://github.com/logstash-plugins/logstash-input-lumberjack/issues/33
 # 1.0.0

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "concurrent-ruby"
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'stud'
   s.add_development_dependency 'logstash-codec-multiline'
   s.add_development_dependency "flores"
   s.add_development_dependency "stud"

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-lumberjack'
-  s.version         = '1.0.1'
+  s.version         = '1.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/lumberjack_spec.rb
+++ b/spec/inputs/lumberjack_spec.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require "spec_helper"
+require_relative "../spec_helper"
 require "stud/temporary"
 require 'logstash/inputs/lumberjack'
 require "logstash/codecs/plain"

--- a/spec/logstash/circuit_breaker_spec.rb
+++ b/spec/logstash/circuit_breaker_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require_relative "../spec_helper"
 require "logstash/circuit_breaker"
 
 class DummyErrorTest < StandardError; end

--- a/spec/logstash/size_queue_timeout_spec.rb
+++ b/spec/logstash/size_queue_timeout_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require_relative "../spec_helper"
 require "logstash/sized_queue_timeout"
 require "flores/random"
 require "stud/try"


### PR DESCRIPTION
When running the integration tests inside a logstash distribution, the
lumbejrack specs were not able to load the tests helpers.