### PR TITLE
Deprecation warning for the `Concurrent::Condition` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.3
+  - Fix `concurrent-ruby` deprecation warning (https://github.com/logstash-plugins/logstash-input-lumberjack/pull/39)
+  - Remove deplicate declaration of the threadpool
 # 1.0.2
   - Use a `require_relative` for loading the spec helpers. (https://github.com/logstash-plugins/logstash-input-lumberjack/pull/35)
 # 1.0.1

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -52,16 +52,9 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
       :ssl_certificate => @ssl_certificate, :ssl_key => @ssl_key,
       :ssl_key_passphrase => @ssl_key_passphrase)
 
-    # Limit the number of thread that can be created by the
-    # Limit the number of thread that can be created by the 
-    # lumberjack output, if the queue is full the input will 
-    # start rejecting new connection and raise an exception
-    @threadpool = Concurrent::ThreadPoolExecutor.new(
-      :min_threads => 1,
-      :max_threads => @max_clients,
-      :max_queue => 1, # in concurrent-ruby, bounded queue need to be at least 1.
-      fallback_policy: :abort
-    )
+    # Create a reusable threadpool, we do not limit the number of connections
+    # to the input, the circuit breaker with the timeout should take care 
+    # of `blocked` threads and prevent logstash to go oom.
     @threadpool = Concurrent::CachedThreadPool.new(:idletime => 15)
 
     # in 1.5 the main SizeQueue doesnt have the concept of timeout

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -29,12 +29,8 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
   # SSL key passphrase to use.
   config :ssl_key_passphrase, :validate => :password
 
-  # The lumberjack input using a fixed thread pool to do the actual work and
-  # will accept a number of client in a queue, before starting to refuse new
-  # connection. This solve an issue when logstash-forwarder clients are 
-  # trying to connect to logstash which have a blocked pipeline and will 
-  # make logstash crash with an out of memory exception.
-  config :max_clients, :validate => :number, :default => 1000
+  # This setting no longer has any effect and will be removed in a future release.
+  config :max_clients, :validate => :number, :deprecated => "This setting no longer has any effect. See https://github.com/logstash-plugins/logstash-input-lumberjack/pull/12 for the history of this change"
 
   # TODO(sissel): Add CA to authenticate clients with.
 

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-lumberjack'
-  s.version         = '1.0.2'
+  s.version         = '1.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
We were using this class to only check if the lock had a timeout, it was
simplier to only use the native `ConditionVariable` class and use
a monotomic clock to check if we had actually reached a timeout.