### PR TITLE
Reorganize the errors handling

### DIFF
--- a/lib/logstash/circuit_breaker.rb
+++ b/lib/logstash/circuit_breaker.rb
@@ -4,7 +4,11 @@ require "cabin"
 module LogStash
   # Largely inspired by Martin's fowler circuit breaker
   class CircuitBreaker
+    # Raised when too many errors has occured and we refuse to execute the block
     class OpenBreaker < StandardError; end
+
+    # Raised when we catch an error that we count
+    class HalfOpenBreaker < StandardError; end
 
     # Error threshold before opening the breaker,
     # if the breaker is open it wont execute the code.
@@ -48,6 +52,8 @@ module LogStash
     rescue *@exceptions => e
       logger.warn("CircuitBreaker::rescuing exceptions", :name => @name, :exception => e.class)
       increment_errors(e)
+
+      raise HalfOpenBreaker
     end
 
     def closed?

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -112,7 +112,7 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
         # his payload.
       rescue LogStash::CircuitBreaker::OpenBreaker,
         LogStash::CircuitBreaker::HalfOpenBreaker => e
-        logger.warn("Lumberjack input: connection closed, backing off", :exception => e.class)
+        logger.warn("Lumberjack input: The circuit breaker has detected a slowdown or stall in the pipeline, the input is closing the current connection and rejecting new connection until the pipeline recover.", :exception => e.class)
       rescue => e # If we have a malformed packet we should handle that so the input doesn't crash completely.
         @logger.error("Lumberjack input: unhandled exception", :exception => e, :backtrace => e.backtrace)
       end

--- a/lib/logstash/sized_queue_timeout.rb
+++ b/lib/logstash/sized_queue_timeout.rb
@@ -9,7 +9,7 @@ module LogStash
   class SizedQueueTimeout
     class TimeoutError < StandardError; end
 
-    DEFAULT_TIMEOUT = 2 # in seconds
+    DEFAULT_TIMEOUT = 10 # in seconds
 
     def initialize(max_size, options = {})
       # `concurrent-ruby` are deprecating the `Condition`

--- a/lib/logstash/sized_queue_timeout.rb
+++ b/lib/logstash/sized_queue_timeout.rb
@@ -9,7 +9,7 @@ module LogStash
   class SizedQueueTimeout
     class TimeoutError < StandardError; end
 
-    DEFAULT_TIMEOUT = 10 # in seconds
+    DEFAULT_TIMEOUT = 5 # in seconds
 
     def initialize(max_size, options = {})
       # `concurrent-ruby` are deprecating the `Condition`

--- a/spec/inputs/lumberjack_spec.rb
+++ b/spec/inputs/lumberjack_spec.rb
@@ -7,6 +7,7 @@ require "logstash/codecs/multiline"
 require "logstash/event"
 require "lumberjack/client"
 
+Thread.abort_on_exception = true
 describe LogStash::Inputs::Lumberjack do
   let(:connection) { double("connection") }
   let(:certificate) { LogStashTest.certificate }
@@ -41,7 +42,7 @@ describe LogStash::Inputs::Lumberjack do
       let(:codec) { LogStash::Codecs::Multiline.new("pattern" => '\n', "what" => "previous") }
       it "clone the codec per connection" do
         expect(lumberjack.codec).to receive(:clone).once
-        expect(lumberjack).to receive(:invoke).and_throw(:msg)
+        expect(lumberjack).to receive(:invoke) { break }
         lumberjack.run(queue)
       end
     end

--- a/spec/logstash/circuit_breaker_spec.rb
+++ b/spec/logstash/circuit_breaker_spec.rb
@@ -14,33 +14,55 @@ describe LogStash::CircuitBreaker do
 
   subject { LogStash::CircuitBreaker.new("testing", options) }
 
-
-  it "closed by default" do
-    expect(subject.closed?).to eq(true)
-  end
-
-  context "when having too many errors" do
-    let(:future_time) { Time.now + 3600 }
-    before do
-      subject.execute do
-        raise DummyErrorTest
-      end
+  context "when the breaker is closed" do
+    it "closed by default" do
+      expect(subject.closed?).to eq(true)
     end
 
-    it "raised an exception if we have too many errors" do
+    it "always raise an exception if an errors occur" do
+      expect {
+        subject.execute do
+          raise DummyErrorTest
+        end
+      }.to raise_error(LogStash::CircuitBreaker::HalfOpenBreaker)
+    end
+
+    it "open if we pass the errors threadshold" do
+      expect {
+        subject.execute do
+          raise DummyErrorTest
+        end
+      }.to raise_error(LogStash::CircuitBreaker::HalfOpenBreaker)
+
       expect {
         subject.execute do
           raise DummyErrorTest
         end
       }.to raise_error(LogStash::CircuitBreaker::OpenBreaker)
     end
+  end
 
-    it "sets the breaker to open" do
+  context "When the breaker is open" do
+    let(:future_time) { Time.now + 3600 }
+
+    before do
+      # trip the breaker
+      (error_threshold + 1).times do
+        begin
+          subject.execute do
+            raise DummyErrorTest
+          end
+        rescue
+        end
+      end
+    end
+
+    it "#closed? should return false" do
       expect(subject.closed?).to eq(false)
     end
 
     it "resets the breaker after the time before retry" do
-      expect(Time).to receive(:now).at_least(1).and_return(future_time)
+      expect(Time).to receive(:now).at_least(2).and_return(future_time)
       expect(subject.closed?).to eq(true)
     end
 
@@ -51,7 +73,7 @@ describe LogStash::CircuitBreaker do
         subject.execute do
           runned = true
         end
-      rescue LogStash::CircuitBreaker::OpenBreaker
+      rescue LogStash::CircuitBreaker::OpenBreaker 
       end
 
       expect(runned).to eq(false)


### PR DESCRIPTION
This changes introduce a new way to do the errors handling,
everytime that the circuit breaker doesn't run a piece of code we will
still throw a `HalfOpen` exception. In the lumberjack input case this
allow the lumberjack library to know that something was wrong with the
packet and stop the connection. Stopping the connection will force the
client to do a retransmit of the payload.
