### PR TITLE
Add support for json data frames

### DIFF
--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -1,6 +1,10 @@
 # encoding: utf-8
 require "logstash/inputs/base"
 require "logstash/namespace"
+require "lumberjack"
+
+# use Logstash provided json decoder
+Lumberjack::json = LogStash::Json
 
 # Receive events using the lumberjack protocol.
 #

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -103,7 +103,7 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
       begin
         # If any errors occur in from the events the connection should be closed in the
         # library ensure block and the exception will be handled here
-        client = ConnectionDecorator.new(EventDecoration.new, code, connection)
+        client = ConnectionDecorator.new(EventDecoration.new, codec, connection)
         client.run(&block)
 
         # When too many errors happen inside the circuit breaker it will throw

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -73,16 +73,13 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
       if @circuit_breaker.closed?
         connection = @lumberjack.accept # Blocking call that creates a new connection
 
-        invoke(connection, @codec.clone) do |code, _codec, fields|
-          handler = code == :json ? json_event : data_event
-          handler(_codec, fields) do |event|
-            begin
-              @circuit_breaker.execute {
-                @buffered_queue.push(event, @congestion_threshold)
-              }
-              rescue => e
-                raise e
-            end
+        invoke(connection, @codec.clone) do |event|
+          begin
+            @circuit_breaker.execute {
+              @buffered_queue.push(event, @congestion_threshold)
+            }
+          rescue => e
+            raise e
           end
         end
       else
@@ -98,53 +95,20 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
 
   private
   def data_event(line_codec, fields)
-    line = fields.delete("line")
-    line_codec.decode(line) do |event|
-      begin
-        decorate(event)
-        fields.each { |k,v| event[k] = v; v.force_encoding(Encoding::UTF_8) }
-        yield event
-      rescue => e
-        raise e
-      end
-    end
-  end
-
-  private
-  def json_event(line_codec, map)
-    if field.is_a?(Array)
-      fields.each do |item|
-        json_event(line_codec, item) { |event| yield event }
-      end
-    else
-      line = map.delete("line")
-      if line.nil?
-        event = LogStash::Event.new(map)
-        decorate(event)
-        yield event
-      else
-        line_codec.decode(line) do |event|
-          decorate(event)
-          map.each { |k,v| event[k] = v }
-          yield event
-        end
-      end
-    end
   end
 
   private
   def invoke(connection, codec, &block)
     @threadpool.post do
       begin
-        # If any errors occur in from the events the connection should be closed in the 
+        # If any errors occur in from the events the connection should be closed in the
         # library ensure block and the exception will be handled here
-        connection.run do |code, fields|
-          block.call(code, codec, fields)
-        end
+        client = Client.new(Decoration.new, code, connection)
+        client.run(&block)
 
-        # When too many errors happen inside the circuit breaker it will throw 
+        # When too many errors happen inside the circuit breaker it will throw
         # this exception and start refusing connection. The bubbling of theses
-        # exceptions make sure that the lumberjack library will close the current 
+        # exceptions make sure that the lumberjack library will close the current
         # connection which will force the client to reconnect and restransmit
         # his payload.
       rescue LogStash::CircuitBreaker::OpenBreaker,
@@ -163,4 +127,69 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
       end
     end
   end
+
+  class Decoration < LogStash::Inputs::Base
+    public
+    def decorate(event)
+      super(event)
+    end
+  end # class Decoration
+
+  class Client
+    def initialize(decoration, codec, connection)
+      @decoration = decoration
+      @connection = connection
+      @codec = codec
+    end
+
+    public
+    def run(&block)
+      @connection.run do |type, event|
+        case type
+        when :json; json_event(event, &block)
+        when :data; data_event(event, &block)
+        else; raise "unknown event type received"
+        end
+      end
+    end
+
+    private
+    def json_event(map, &block)
+      if map.is_a?(Array)
+        map.each { |item| json_event(item, &block) }
+      else
+        line = map.delete("line")
+        if line.nil?
+          event = LogStash::Event.new(map)
+          decorate(event)
+          yield event
+        else
+          @codec.decode(line) do |decoded|
+            decorate(decoded)
+            map.each { |k,v| decoded[k] = v }
+            yield decoded
+          end
+        end
+      end
+    end
+
+    private
+    def data_event(fields)
+      line = fields.delete("line")
+      @codec.decode(line) do |event|
+        begin
+          decorate(event)
+          fields.each { |k,v| event[k] = v; v.force_encoding(Encoding::UTF_8) }
+          yield event
+        rescue => e
+          raise e
+        end
+      end
+    end
+
+    private
+    def decorate(event)
+      @decoration.decorate(event)
+    end
+  end # Client
 end # class LogStash::Inputs::Lumberjack

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -135,16 +135,16 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
     end
   end # class EventDecoration
 
-  class ConnectionDecorator
+  class ConnectionDecorator < SimpleDelegator
     def initialize(event_decoration, codec, connection)
+      super(connection)
       @event_decoration = event_decoration
-      @connection = connection
       @codec = codec
     end
 
     public
     def run(&block)
-      @connection.run do |type, event|
+      super do |type, event|
         case type
         when :json; json_event(event, &block)
         when :data; data_event(event, &block)

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -76,8 +76,9 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
       # Wrappingu the accept call into a CircuitBreaker
       if @circuit_breaker.closed?
         connection = @lumberjack.accept # Blocking call that creates a new connection
-
-        invoke(connection, @codec.clone) do |event|
+        connection = ConnectionDecorator.new(EventDecoration.new,
+                                             @codec.clone, connection)
+        invoke(connection) do |event|
           begin
             @circuit_breaker.execute {
               @buffered_queue.push(event, @congestion_threshold)
@@ -98,13 +99,12 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
   end # def run
 
   private
-  def invoke(connection, codec, &block)
+  def invoke(connection, &block)
     @threadpool.post do
       begin
         # If any errors occur in from the events the connection should be closed in the
         # library ensure block and the exception will be handled here
-        client = ConnectionDecorator.new(EventDecoration.new, codec, connection)
-        client.run(&block)
+        connection.run(&block)
 
         # When too many errors happen inside the circuit breaker it will throw
         # this exception and start refusing connection. The bubbling of theses
@@ -112,7 +112,7 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
         # connection which will force the client to reconnect and restransmit
         # his payload.
       rescue LogStash::CircuitBreaker::OpenBreaker,
-        LogStash::CircuitBreaker::HalfOpenBreaker => e
+             LogStash::CircuitBreaker::HalfOpenBreaker => e
         logger.warn("Lumberjack input: The circuit breaker has detected a slowdown or stall in the pipeline, the input is closing the current connection and rejecting new connection until the pipeline recover.", :exception => e.class)
       rescue => e # If we have a malformed packet we should handle that so the input doesn't crash completely.
         @logger.error("Lumberjack input: unhandled exception", :exception => e, :backtrace => e.backtrace)

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -73,14 +73,15 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
       if @circuit_breaker.closed?
         connection = @lumberjack.accept # Blocking call that creates a new connection
 
-        invoke(connection, @codec.clone) do |_codec, line, fields|
-          _codec.decode(line) do |event|
+        invoke(connection, @codec.clone) do |code, _codec, fields|
+          handler = code == :json ? json_event : data_event
+          handler(_codec, fields) do |event|
             begin
-              decorate(event)
-              fields.each { |k,v| event[k] = v; v.force_encoding(Encoding::UTF_8) }
-              @circuit_breaker.execute { @buffered_queue.push(event, @congestion_threshold) }
-            rescue => e
-              raise e
+              @circuit_breaker.execute {
+                @buffered_queue.push(event, @congestion_threshold)
+              }
+              rescue => e
+                raise e
             end
           end
         end
@@ -96,13 +97,49 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
   end # def run
 
   private
+  def data_event(line_codec, fields)
+    line = fields.delete("line")
+    line_codec.decode(line) do |event|
+      begin
+        decorate(event)
+        fields.each { |k,v| event[k] = v; v.force_encoding(Encoding::UTF_8) }
+        yield event
+      rescue => e
+        raise e
+      end
+    end
+  end
+
+  private
+  def json_event(line_codec, map)
+    if field.is_a?(Array)
+      fields.each do |item|
+        json_event(line_codec, item) { |event| yield event }
+      end
+    else
+      line = map.delete("line")
+      if line.nil?
+        event = LogStash::Event.new(map)
+        decorate(event)
+        yield event
+      else
+        line_codec.decode(line) do |event|
+          decorate(event)
+          map.each { |k,v| event[k] = v }
+          yield event
+        end
+      end
+    end
+  end
+
+  private
   def invoke(connection, codec, &block)
     @threadpool.post do
       begin
         # If any errors occur in from the events the connection should be closed in the 
         # library ensure block and the exception will be handled here
-        connection.run do |fields|
-          block.call(codec, fields.delete("line"), fields)
+        connection.run do |code, fields|
+          block.call(code, codec, fields)
         end
 
         # When too many errors happen inside the circuit breaker it will throw 

--- a/spec/inputs/connection_spec.rb
+++ b/spec/inputs/connection_spec.rb
@@ -5,17 +5,17 @@ require 'logstash/inputs/lumberjack'
 require "logstash/inputs/base"
 require "logstash/codecs/plain"
 
-describe LogStash::Inputs::Lumberjack::Client do
-  let(:decoration) { LogStash::Inputs::Lumberjack::Decoration.new }
+describe LogStash::Inputs::Lumberjack::ConnectionDecorator do
+  let(:decoration) { LogStash::Inputs::Lumberjack::EventDecoration.new }
   let(:codec) { LogStash::Codecs::Plain.new }
   let(:events) { Array.new }
   let(:receiver) { Proc.new { |event| events << event.to_hash } }
   let(:connection) {double("connection")}
   let(:client) {
-    LogStash::Inputs::Lumberjack::Client.new(decoration, codec.clone, connection)
+    LogStash::Inputs::Lumberjack::ConnectionDecorator.new(decoration, codec.clone, connection)
   }
 
-  context "With data frame" do
+  context "Receiving data frame" do
     it "should accept event with line field" do
       allow(connection).to receive(:run).and_yield(:data, {
         "line" => "foobar line",
@@ -36,7 +36,7 @@ describe LogStash::Inputs::Lumberjack::Client do
     end
   end
 
-  context "With json data frame" do
+  context "Receiving json data frame" do
     it "should accept and decode event with line field (backwards compatibility)" do
       allow(connection).to receive(:run).and_yield(:json, {
         "line" => "foobar line",

--- a/spec/inputs/connection_spec.rb
+++ b/spec/inputs/connection_spec.rb
@@ -1,0 +1,78 @@
+# encoding: utf-8
+
+require_relative "../spec_helper"
+require 'logstash/inputs/lumberjack'
+require "logstash/inputs/base"
+require "logstash/codecs/plain"
+
+describe LogStash::Inputs::Lumberjack::Client do
+  let(:decoration) { LogStash::Inputs::Lumberjack::Decoration.new }
+  let(:codec) { LogStash::Codecs::Plain.new }
+  let(:events) { Array.new }
+  let(:receiver) { Proc.new { |event| events << event.to_hash } }
+  let(:connection) {double("connection")}
+  let(:client) {
+    LogStash::Inputs::Lumberjack::Client.new(decoration, codec.clone, connection)
+  }
+
+  context "With data frame" do
+    it "should accept event with line field" do
+      allow(connection).to receive(:run).and_yield(:data, {
+        "line" => "foobar line",
+        "extra" => "extra value"
+      })
+      client.run(&receiver)
+
+      event = events.shift
+      expect(event["message"]).to eq("foobar line")
+      expect(event["extra"]).to eq("extra value")
+    end
+
+    it "should not accept event without line field" do
+      allow(connection).to receive(:run).and_yield(:data, {
+        "extra" => "extra value"
+      })
+      expect {client.run(&receiver) }.to raise_error
+    end
+  end
+
+  context "With json data frame" do
+    it "should accept and decode event with line field (backwards compatibility)" do
+      allow(connection).to receive(:run).and_yield(:json, {
+        "line" => "foobar line",
+        "extra" => "extra value"
+      })
+      client.run(&receiver)
+
+      event = events.shift
+      expect(event["message"]).to eq("foobar line")
+      expect(event["extra"]).to eq("extra value")
+    end
+
+    it "should accept event without line field" do
+      allow(connection).to receive(:run).and_yield(:json, {
+        "extra" => "extra value"
+      })
+
+      client.run(&receiver)
+
+      event = events.shift
+      expect(event["extra"]).to eq("extra value")
+    end
+
+    it "should accept and split json array into multiple events" do
+      allow(connection).to receive(:run).and_yield(:json, [
+        {"line" => "event0"},
+        {"line" => "event1"},
+        {"line" => "event2"},
+      ])
+      client.run(&receiver)
+
+      expect(events.length).to eq(3)
+      expect(events[0]["message"]).to eq("event0")
+      expect(events[1]["message"]).to eq("event1")
+      expect(events[2]["message"]).to eq("event2")
+    end
+  end
+
+end


### PR DESCRIPTION
We try to be backwards compatible here. Users upgrading from logstash-forwarder to filebeat only have to update the input plugin, but no config file.

Upgrade path would first require to upgrade the input plugin in logstash (which will support both, logstash-forwarder and filebeat) and thereafter replace LSF with filebeat.

Even for json based input the configured codec is still applied on the line field (if present), so users switching from LSF to filebeat do not have to adapt any configuration.