### PR TITLE
Add support for `stream_identity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+ - Add support for `stream_identity` to make the lumberjack input able to do disambiguation of file when using the multiline codec #53
+
 ## 2.0.4
  - Update `ruby-lumberjack` dependency to 0.0.26
   

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-lumberjack'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'jls-lumberjack', '~> 0.0.26'
   s.add_runtime_dependency "concurrent-ruby"
+  s.add_runtime_dependency 'logstash-codec-multiline', "~> 2.0.4"
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'logstash-codec-multiline', "~> 2.0.4"
   s.add_development_dependency "flores"
   s.add_development_dependency "stud"
 end

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
 
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'jls-lumberjack', ['>=0.0.26']
+  s.add_runtime_dependency 'jls-lumberjack', '~> 0.0.26'
   s.add_runtime_dependency "concurrent-ruby"
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'logstash-codec-multiline'
+  s.add_development_dependency 'logstash-codec-multiline', "~> 2.0.4"
   s.add_development_dependency "flores"
   s.add_development_dependency "stud"
 end

--- a/spec/inputs/lumberjack_spec.rb
+++ b/spec/inputs/lumberjack_spec.rb
@@ -37,12 +37,19 @@ describe LogStash::Inputs::Lumberjack do
       let(:events_map) do
         [
           { "host" => "machineA", "file" => "/var/log/line", "line" => "2015-11-10 10:14:38,907 line 1" },
+          { "host" => "machineA", "file" => "/var/log/other", "line" => "2015-11-10 10:14:38,907 xline 1" },
           { "host" => "machineA", "file" => "/var/log/line", "line" => "line 1.1" },
+          { "host" => "machineA", "file" => "/var/log/other", "line" => "xline 1.1" },
           { "host" => "machineA", "file" => "/var/log/line", "line" => "2015-11-10 10:16:38,907 line 2" },
+          { "host" => "machineA", "file" => "/var/log/other", "line" => "2015-11-10 10:16:38,907 xline 2" },
           { "host" => "machineA", "file" => "/var/log/line", "line" => "line 2.1" },
+          { "host" => "machineA", "file" => "/var/log/other", "line" => "xline 2.1" },
           { "host" => "machineA", "file" => "/var/log/line", "line" => "line 2.2" },
+          { "host" => "machineA", "file" => "/var/log/other", "line" => "xline 2.2" },
           { "host" => "machineA", "file" => "/var/log/line", "line" => "line 2.3" },
-          { "host" => "machineA", "file" => "/var/log/line", "line" => "2015-11-10 10:18:38,907 line 3" }
+          { "host" => "machineA", "file" => "/var/log/other", "line" => "xline 2.3" },
+          { "host" => "machineA", "file" => "/var/log/line", "line" => "2015-11-10 10:18:38,907 line 3" },
+          { "host" => "machineA", "file" => "/var/log/other", "line" => "2015-11-10 10:18:38,907 xline 3" }
         ]
       end
 
@@ -58,10 +65,13 @@ describe LogStash::Inputs::Lumberjack do
         events_map.each { |e| lumberjack.create_event(e) { |e| queue << e } }
         lumberjack.stop
 
-        expect(queue.size).to eq(3)
+        expect(queue.size).to eq(6)
         expect(queue.collect { |e| e["message"] }).to include("2015-11-10 10:14:38,907 line 1\nline 1.1",
+                                                              "2015-11-10 10:14:38,907 xline 1\nxline 1.1",
                                                               "2015-11-10 10:16:38,907 line 2\nline 2.1\nline 2.2\nline 2.3",
-                                                              "2015-11-10 10:18:38,907 line 3")
+                                                              "2015-11-10 10:16:38,907 xline 2\nxline 2.1\nxline 2.2\nxline 2.3",
+                                                              "2015-11-10 10:18:38,907 line 3",
+                                                              "2015-11-10 10:18:38,907 xline 3")
       end
     end
   end


### PR DESCRIPTION
Stream identity allow to use metadata coming from the LSF to be used
as differentiator for the plugins, in this case the hostname + the file
is use, this allow the multiline codec to correctly merged events.

This PR also introduce a method named `create_event` that take the
direct output of the library to interact with the codec, this make the
testing of this new behavior easier.

Also when we call, stop on the plugin it will try to flush the content
of his buffer to the queue before shutting down.

Fixes: https://github.com/logstash-plugins/logstash-input-lumberjack/issues/63