### PR TITLE
Make the congestion backoff delay configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.6
+ - Expose the `congestion_backoff_delay` to the user to allow them to control the recovering time when back pressure happen. #71
 ## 2.0.5
  - Add support for `stream_identity` to make the lumberjack input able to do disambiguation of file when using the multiline codec #53
 

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-lumberjack'
-  s.version         = '2.0.5'
+  s.version         = '2.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR introducte the `congestion_backoff_delay` config, this allow the
user to configure the amount of time the input should wait when the
CircuitBreaker open, the default is 30s, this value can be too high for
some environment.
