### PR TITLE
Disable the `IdentityMap` when no multiline codec is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.0.8
+  - Do not use the IdentityMap unless we explicitely use the multiline codec #77
 # 2.0.7
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.0.6

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -64,14 +64,16 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
     @circuit_breaker = LogStash::CircuitBreaker.new("Lumberjack input",
                             :exceptions => [LogStash::SizedQueueTimeout::TimeoutError])
 
-    @codec = LogStash::Codecs::IdentityMapCodec.new(@codec)
+    if need_identity_map?
+      @codec = LogStash::Codecs::IdentityMapCodec.new(@codec)
+      @codec.eviction_block(method(:flush_event))
+    end
   end # def register
 
   def run(output_queue)
     @output_queue = output_queue
     start_buffer_broker
 
-    @codec.eviction_block(method(:flush_event))
 
     # Accepting new events coming from LSF
     while !stop? do
@@ -165,5 +167,9 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
         @output_queue << @buffered_queue.pop_no_timeout
       end
     end
+  end
+
+  def need_identity_map?
+    @codec.kind_of?(LogStash::Codecs::Multiline)
   end
 end # class LogStash::Inputs::Lumberjack

--- a/logstash-input-lumberjack.gemspec
+++ b/logstash-input-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-lumberjack'
-  s.version         = '2.0.7'
+  s.version         = '2.0.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
When no multiline codec are specified we wont use the `IdentityMap`, In some circonstance the identity could reach the identity map limit when the files would never expire.
