### PR TITLE
Reset errors_count after successful execute()

### DIFF
--- a/lib/logstash/circuit_breaker.rb
+++ b/lib/logstash/circuit_breaker.rb
@@ -43,10 +43,11 @@ module LogStash
         else
           @block.call(args)
         end
-
+        
+        reset
+        
         if state == :half_open
           logger.warn("CircuitBreaker::Close", :name => @name)
-          reset
         end
       end
     rescue *@exceptions => e


### PR DESCRIPTION
After an intermittent issue is resolved in the pipeline, the `errors_count` is not reset even after a future successful execution.
Eventually, circuit breaker to stop accepting future request.

This patch makes circuit breaker accept future request after the intermittent issue is resolved.
